### PR TITLE
Feature: Add footer prop to columns array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # CHANGELOG
 
+## 0.4.7
+
+_2023-09-28_
+
+### Features
+
+- added a `footer` prop to each `column` object in the `columns` array. allows the user to create footer cell columns.
+- `footerComponent` will still provide a more customizable footer experience
+- hopefully fix issues with the auto-calculation of tables when `minTableHeight` and/or `maxTableHeight` is used.
+- slimmed down some of the opinionated CSS, giving the user more control over header and body styles
+
 ## 0.4.6
 
 _2023-09-28_

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -11,6 +11,7 @@ import { Example7, Source as Example7Code } from "./examples/07-controlled";
 import { Example8, Source as Example8Code } from "./examples/08-header";
 import { Example9, Source as Example9Code } from "./examples/09-scroll";
 import { Example10, Source as Example10Code } from "./examples/10-footer";
+import { Example11, Source as Example11Code } from "./examples/11-heights";
 
 const router = createHashRouter([
   {
@@ -90,6 +91,14 @@ const router = createHashRouter([
     element: (
       <Page title="Footer" code={Example10Code}>
         <Example10 />
+      </Page>
+    )
+  },
+  {
+    path: "/heights",
+    element: (
+      <Page title="Table Heights" code={Example11Code}>
+        <Example11 />
       </Page>
     )
   },

--- a/example/src/ColumnProps.tsx
+++ b/example/src/ColumnProps.tsx
@@ -4,6 +4,8 @@ import styled from "styled-components";
 import { InlineCode } from "./components/library/InlineCode";
 
 const StyledTable = styled(Table)`
+  border: 1px solid #ececec;
+
   .react-fluid-table-header {
     background-color: #282a36;
   }
@@ -119,6 +121,17 @@ const data: PropData[] = [
         that cell at the particular row. This will be rendered in place of a cell container, so make
         sure to use the given <code>style</code> prop to get the calculated cell width. If this
         property is defined, then <code>content</code> will be igored.
+      </div>
+    )
+  },
+  {
+    prop: "footer",
+    type: "FooterElement",
+    description: (
+      <div>
+        This property allows you to customize the content inside of a footer cell. The library will create
+        a cell container for you with the proper column widths and resizability. If this field is
+        defined, then this will get rendered inside of the cell container in the footer.
       </div>
     )
   }

--- a/example/src/Page.tsx
+++ b/example/src/Page.tsx
@@ -96,6 +96,9 @@ const LinkContainer = () => (
     <Menu.Item as={Link} to="/scroll">
       Methods
     </Menu.Item>
+    <Menu.Item as={Link} to="/heights">
+      Table Heights
+    </Menu.Item>
     <Menu.Item as={Link} to="/footer">
       Footer
     </Menu.Item>

--- a/example/src/Props.tsx
+++ b/example/src/Props.tsx
@@ -14,6 +14,8 @@ const Container = styled.div`
 `;
 
 const Table = styled(BaseTable)`
+  border: 1px solid #ececec;
+
   .react-fluid-table-header {
     background-color: #282a36;
   }
@@ -406,6 +408,315 @@ const Props = () => (
         </Item>
       ))}
     </List>
+    <Header dividing size="small" color="grey">
+      Interfaces
+    </Header>
+    <Snippet code={`import { CSSProperties, ForwardedRef, ReactNode } from "react";
+
+type SortDirection = "ASC" | "DESC" | null;
+
+interface ExpanderProps {
+  /**
+   * whether or not the row is expanded
+   */
+  isExpanded: boolean;
+  /**
+   * handler for clicking the expansion button
+   */
+  onClick: (event?: React.MouseEvent<Element, MouseEvent>) => void;
+  /**
+   * required style for the expander
+   */
+  style: CSSProperties;
+}
+
+interface CellProps<T> {
+  /**
+   * the data for the row
+   */
+  row: T;
+  /**
+   * the index of the row
+   */
+  index: number;
+  /**
+   * an optional function that can be used to clear the size cache
+   */
+  clearSizeCache: (dataIndex: number, forceUpdate?: boolean) => void;
+  /**
+   * optional custom styles for each cell
+   */
+  style?: CSSProperties;
+}
+
+interface HeaderProps {
+  /**
+   * the onclick handler for the header cell
+   * @param e mouse event
+   * @returns void
+   */
+  onClick: (e: React.MouseEvent<Element, MouseEvent>) => void;
+  /**
+   * required style for the header
+   */
+  style: CSSProperties;
+  /**
+   * the direction of the sort, if applicable
+   */
+  sortDirection: SortDirection;
+}
+
+interface RowRenderProps<T> {
+  /**
+   * the data for the row
+   */
+  row: T;
+  /**
+   * the index of the row
+   */
+  index: number;
+  /**
+   * required row position styles
+   */
+  style: CSSProperties;
+  /**
+   * the cells for the row
+   */
+  children: ReactNode;
+  /**
+   * the className for the row-renderer
+   */
+  className?: string;
+}
+
+interface SubComponentProps<T> {
+  /**
+   * the data for the row
+   */
+  row: T;
+  /**
+   * the index of the row
+   */
+  index: number;
+  /**
+   * whether or not the row is expanded
+   */
+  isExpanded: boolean;
+  /**
+   * an optional function that can be used to clear the size cache
+   */
+  clearSizeCache: (dataIndex: number, forceUpdate?: boolean) => void;
+}
+
+interface FooterProps<T> {
+  /**
+   * exposes the widths of each column to the footer
+   */
+  widths: number[];
+  rows: T[];
+}
+
+interface FooterCellProps<T> {
+  /**
+   * the column that the current footer cell is pulling from
+   */
+  column: ColumnProps<T>;
+  /**
+   * the calculated width of the cell
+   */
+  width: number;
+  /**
+   * all the rows in the table. this can be useful for aggregation
+   */
+  rows: T[];
+}
+
+interface ColumnProps<T> {
+  /**
+   * The unique identifier for a particular column. This is also used as an index
+   * to get the particular value out of the row in order to display.
+   */
+  key: string;
+  /**
+   * The name of the header column, or a component to return a customized header cell.
+   */
+  header?: string | ((props: HeaderProps) => JSX.Element);
+  /**
+   * The width of a column in pixels. If this is set, the column will not resize.
+   */
+  width?: number;
+  /**
+   * The minimum width of a column in pixels. On resize, the column will never
+   * dip below this width.
+   */
+  minWidth?: number;
+  /**
+   * The maximum width of a column in pixels. On resize, the column will never
+   * grow beyond this width.
+   */
+  maxWidth?: number;
+  /**
+   * Determines whether or not a column is sortable.
+   */
+  sortable?: boolean;
+  /**
+   * Marks this cell as an expansion cell. The style is pre-determined, and does the
+   * functionalitty of collapsing/expanding a row.
+   */
+  expander?: boolean | ((props: ExpanderProps) => ReactNode);
+  /**
+   * Used to render custom content inside of a cell. This is useful for rendering different
+   * things inside of the react-fluid-table cell container.
+   */
+  content?: string | number | ((props: CellProps<T>) => ReactNode);
+  /**
+   * An advanced feature, this is used to render an entire cell, including the cell container.
+   * The \`content\` prop is ignored if this property is enabled.
+   */
+  cell?: (props: CellProps<T>) => JSX.Element;
+  /**
+   * specifies whether or not to display a footer cell
+   */
+  footer?: (props: FooterCellProps<T>) => ReactNode;
+}
+
+interface TableRef {
+  scrollTo: (scrollOffset: number) => void;
+  scrollToItem: (index: number, align?: string) => void;
+}
+
+interface TableProps<T> {
+  // required props
+  /**
+   * A list of rows that are to be displayed in the table.
+   */
+  data: T[];
+  /**
+   * This property determines how each cell is going to be rendered.
+   */
+  columns: ColumnProps<T>[];
+
+  // optional props
+  /**
+   * The id of the table.
+   */
+  id?: string;
+  /**
+   * Optional className to override CSS styles.
+   */
+  className?: string;
+  /**
+   * Function that is called when a header cell is sorted.
+   */
+  onSort?: (col: string | null, dir: SortDirection) => void;
+  /**
+   * The column that is sorted by default.
+   */
+  sortColumn?: string;
+  /**
+   * The direction that is sorted by default.
+   */
+  sortDirection?: SortDirection;
+  /**
+   * Specify the height of the table in pixels.
+   */
+  tableHeight?: number;
+  /**
+   * Specify the minimum height of the table in pixels.
+   */
+  minTableHeight?: number;
+  /**
+   * Specify the maximum height of the table in pixels.
+   */
+  maxTableHeight?: number;
+  /**
+   * Specify the width of the table in pixels.
+   */
+  tableWidth?: number;
+  /**
+   * Specify the minimum width of any column. Default: \`80\`.
+   */
+  minColumnWidth?: number;
+  /**
+   * The fixed height of each row in pixels. If \`subComponent\` is specified,
+   * then this will be the fixed height of the portion of the row that is
+   * NOT the subComponent.
+   */
+  rowHeight?: number;
+  /**
+   * specify a fixed header height
+   */
+  headerHeight?: number;
+  /**
+   * Enable or disable row borders. Default: \`false\`.
+   */
+  borders?: boolean;
+  /**
+   * React styles used for customizing the table.
+   */
+  tableStyle?: CSSProperties;
+  /**
+   * React styles used for customizing the header.
+   */
+  headerStyle?: CSSProperties;
+  /**
+   * a className used to customize the header
+   */
+  headerClassname?: string;
+  /**
+   * React styles used for customizing each row. Could be an object or
+   * a function that takes the index of the row and returns an object.
+   */
+  rowStyle?: CSSProperties | ((index: number) => CSSProperties);
+  /**
+   * React className used for customizing each row. Could be an object or
+   * a function that takes the index of the row and returns an object.
+   */
+  rowClassname?: string | ((index: number) => string);
+  /**
+   * React styles used for customizing the footer.
+   */
+  footerStyle?: CSSProperties;
+  /**
+   * a className used to customize the footer
+   */
+  footerClassname?: string;
+  /**
+   * generates a unique identifier for the row
+   * @param row the row
+   * @returns string or number representing the item key
+   */
+  itemKey?: (row: T) => string | number;
+  /**
+   * controlls whether or not the footer is sticky. this is only used if
+   * \`footerComponent\` is specified.
+   */
+  stickyFooter?: boolean;
+  /**
+   * optionally add a footer. NOTE: this overrides the \`footer\` prop of a
+   * column, so use wisely. This gives the user more control over how the
+   * footer is rendered. Can return any value.
+   */
+  footerComponent?: (props: FooterProps<T>) => ReactNode;
+  /**
+   * When a column has \`expander\`, this component will be rendered under the row.
+   */
+  subComponent?: (props: SubComponentProps<T>) => ReactNode;
+  /**
+   * The callback that gets called every time a row is clicked.
+   */
+  onRowClick?: (event: React.MouseEvent<Element, MouseEvent>, data: { index: number }) => void;
+  /**
+   * Custom component to wrap a table row. This provides another way of providing
+   * more row customization options.
+   */
+  rowRenderer?: (props: RowRenderProps<T>) => JSX.Element;
+  /**
+   * a ref for specific table functions
+   */
+  ref?: ForwardedRef<TableRef>;
+}
+`} />
   </Container>
 );
 

--- a/example/src/examples/07-controlled.tsx
+++ b/example/src/examples/07-controlled.tsx
@@ -22,6 +22,11 @@ import { TestData, testData } from "../data";
 
 const StyledTable = styled(Table)`
   margin-top: 10px;
+  border: 1px solid #ececec;
+
+  .react-fluid-table-header {
+    background-color: #dedede;
+  }
 `;
 
 const Background = styled.div`

--- a/example/src/examples/11-heights.tsx
+++ b/example/src/examples/11-heights.tsx
@@ -1,0 +1,179 @@
+import { useEffect, useRef, useState } from "react";
+import { ColumnProps, Table } from "react-fluid-table";
+import { Button, Form, Icon, Input } from "semantic-ui-react";
+import styled from "styled-components";
+import { TestData, testData } from "../data";
+
+const StyledTable = styled(Table)`
+  margin-top: 10px;
+`;
+
+const columns: ColumnProps<TestData>[] = [
+  {
+    key: "id",
+    header: "ID",
+    width: 50
+  },
+  {
+    key: "firstName",
+    header: "First",
+    width: 120
+  },
+  {
+    key: "lastName",
+    header: "Last",
+    width: 120
+  },
+  {
+    key: "email",
+    header: "Email",
+    width: 250
+  }
+];
+
+const Example11 = () => {
+  // hooks
+  const ref = useRef(0);
+  const [size, setSize] = useState(1);
+  const [running, setRunning] = useState(false);
+  const [tableHeight, setTableHeight] = useState(400);
+  const [minTableHeight, setMinTableHeight] = useState(0);
+  const [maxTableHeight, setMaxTableHeight] = useState(0);
+
+  useEffect(() => {
+    const m = ref.current;
+    return () => {
+      window.clearInterval(m);
+    };
+  }, []);
+
+  return (
+    <>
+      <Form>
+        <h4>Change height properties</h4>
+        <Form.Field>
+          <Input
+            label="table height"
+            placeholder="specify table height (<= 0 to disable)"
+            type="number"
+            value={tableHeight.toString()}
+            onChange={e => {
+              setTableHeight(/-?\d+/.test(e.target.value) ? parseInt(e.target.value) : 0);
+            }}
+          />
+        </Form.Field>
+        <Form.Field>
+          <Input
+            label="min table height"
+            placeholder="specify min table height (<= 0 to disable)"
+            type="number"
+            value={minTableHeight.toString()}
+            onChange={e => {
+              setMinTableHeight(/-?\d+/.test(e.target.value) ? parseInt(e.target.value) : 0);
+            }}
+          />
+        </Form.Field>
+        <Form.Field>
+          <Input
+            label="max table height"
+            placeholder="specify max table height (<= 0 to disable)"
+            type="number"
+            value={maxTableHeight.toString()}
+            onChange={e => {
+              setMaxTableHeight(/-?\d+/.test(e.target.value) ? parseInt(e.target.value) : 0);
+            }}
+          />
+        </Form.Field>
+        <div>
+          <Button
+            onClick={() => {
+              window.clearInterval(ref.current);
+              setSize(1);
+              setRunning(true);
+              ref.current = window.setInterval(() => {
+                setSize(prev => prev + 1);
+              }, 1000);
+            }}
+          >
+            Start
+          </Button>
+          <Button
+            onClick={() => {
+              window.clearInterval(ref.current);
+              setRunning(false);
+            }}
+          >
+            Stop
+          </Button>
+          {running && <Icon loading name="spinner" />}
+        </div>
+      </Form>
+      <StyledTable
+        borders
+        data={testData.slice(0, size)}
+        columns={columns}
+        tableHeight={tableHeight}
+        minTableHeight={minTableHeight}
+        maxTableHeight={maxTableHeight}
+      />
+    </>
+  );
+};
+
+const Source = `
+const data = [/* ... */];
+
+const Footer = ({ children }) => (
+  <div style={{ backgroundColor: "white" }}>
+    {children}
+  </div>
+);
+
+const SimpleFooter = ({ stickyFooter }) => {
+  return (
+    <StyledTable
+      borders
+      data={data}
+      columns={columns}
+      tableHeight={400}
+      stickyFooter={stickyFooter}
+      footerStyle={{ backgroundColor: "white" }}
+      footerComponent={() => <Footer>Hello, World</Footer>}
+    />
+  );
+};
+
+const ComplexFooter = ({ stickyFooter }) => {
+  return (
+    <StyledTable
+      borders
+      data={data}
+      columns={columns}
+      tableHeight={400}
+      stickyFooter={stickyFooter}
+      footerStyle={{ backgroundColor: "white" }}
+      footerComponent={({ widths }) => (
+        <Footer>
+          <div style={{ display: "flex" }}>
+            {columns.map((c, i) => {
+              const width = \`\${widths[i]}px\`;
+              const style: React.CSSProperties = {
+                width,
+                minWidth: width,
+                padding: "8px"
+              };
+              return (
+                <div key={c.key} style={style}>
+                  Footer Cell
+                </div>
+              );
+            })}
+          </div>
+        </Footer>
+      )}
+    />
+  );
+};
+`;
+
+export { Example11, Source };

--- a/example/src/examples/11-heights.tsx
+++ b/example/src/examples/11-heights.tsx
@@ -6,6 +6,11 @@ import { TestData, testData } from "../data";
 
 const StyledTable = styled(Table)`
   margin-top: 10px;
+  border: 1px solid #ececec;
+
+  .react-fluid-table-header {
+    background-color: #dedede;
+  }
 `;
 
 const columns: ColumnProps<TestData>[] = [
@@ -123,54 +128,15 @@ const Example11 = () => {
 const Source = `
 const data = [/* ... */];
 
-const Footer = ({ children }) => (
-  <div style={{ backgroundColor: "white" }}>
-    {children}
-  </div>
-);
-
-const SimpleFooter = ({ stickyFooter }) => {
+const AdjustableHeightTable = ({ tableHeight, minTableHeight, maxTableHeignt }) => {
   return (
     <StyledTable
       borders
-      data={data}
+      data={testData}
       columns={columns}
-      tableHeight={400}
-      stickyFooter={stickyFooter}
-      footerStyle={{ backgroundColor: "white" }}
-      footerComponent={() => <Footer>Hello, World</Footer>}
-    />
-  );
-};
-
-const ComplexFooter = ({ stickyFooter }) => {
-  return (
-    <StyledTable
-      borders
-      data={data}
-      columns={columns}
-      tableHeight={400}
-      stickyFooter={stickyFooter}
-      footerStyle={{ backgroundColor: "white" }}
-      footerComponent={({ widths }) => (
-        <Footer>
-          <div style={{ display: "flex" }}>
-            {columns.map((c, i) => {
-              const width = \`\${widths[i]}px\`;
-              const style: React.CSSProperties = {
-                width,
-                minWidth: width,
-                padding: "8px"
-              };
-              return (
-                <div key={c.key} style={style}>
-                  Footer Cell
-                </div>
-              );
-            })}
-          </div>
-        </Footer>
-      )}
+      tableHeight={tableHeight}
+      minTableHeight={minTableHeight}
+      maxTableHeight={maxTableHeight}
     />
   );
 };

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { CSSProperties, ReactNode } from "react";
+import { CSSProperties, ForwardedRef, ReactNode } from "react";
 
 declare module "*.svg" {
   const content: string;
@@ -55,7 +55,7 @@ export interface HeaderProps {
   /**
    * required style for the header
    */
-  style: React.CSSProperties;
+  style: CSSProperties;
   /**
    * the direction of the sort, if applicable
    */
@@ -104,11 +104,27 @@ export interface SubComponentProps<T> {
   clearSizeCache: CacheFunction;
 }
 
-export interface FooterProps {
+export interface FooterProps<T> {
   /**
    * exposes the widths of each column to the footer
    */
   widths: number[];
+  rows: T[];
+}
+
+export interface FooterCellProps<T> {
+  /**
+   * the column that the current footer cell is pulling from
+   */
+  column: ColumnProps<T>;
+  /**
+   * the calculated width of the cell
+   */
+  width: number;
+  /**
+   * all the rows in the table. this can be useful for aggregation
+   */
+  rows: T[];
 }
 
 export interface ColumnProps<T> {
@@ -143,17 +159,21 @@ export interface ColumnProps<T> {
    * Marks this cell as an expansion cell. The style is pre-determined, and does the
    * functionalitty of collapsing/expanding a row.
    */
-  expander?: boolean | ((props: ExpanderProps) => React.ReactNode);
+  expander?: boolean | ((props: ExpanderProps) => ReactNode);
   /**
    * Used to render custom content inside of a cell. This is useful for rendering different
    * things inside of the react-fluid-table cell container.
    */
-  content?: string | number | ((props: CellProps<T>) => React.ReactNode);
+  content?: string | number | ((props: CellProps<T>) => ReactNode);
   /**
    * An advanced feature, this is used to render an entire cell, including the cell container.
    * The `content` prop is ignored if this property is enabled.
    */
   cell?: (props: CellProps<T>) => JSX.Element;
+  /**
+   * specifies whether or not to display a footer cell
+   */
+  footer?: (props: FooterCellProps<T>) => ReactNode;
 }
 
 export interface TableRef {
@@ -269,13 +289,15 @@ export interface TableProps<T> {
    */
   stickyFooter?: boolean;
   /**
-   * optionally add a footer
+   * optionally add a footer. NOTE: this overrides the `footer` prop of a
+   * column, so use wisely. This gives the user more control over how the
+   * footer is rendered. Can return any value.
    */
-  footerComponent?: (props: FooterProps) => React.ReactNode;
+  footerComponent?: (props: FooterProps<T>) => ReactNode;
   /**
    * When a column has `expander`, this component will be rendered under the row.
    */
-  subComponent?: (props: SubComponentProps<T>) => React.ReactNode;
+  subComponent?: (props: SubComponentProps<T>) => ReactNode;
   /**
    * The callback that gets called every time a row is clicked.
    */
@@ -288,7 +310,7 @@ export interface TableProps<T> {
   /**
    * a ref for specific table functions
    */
-  ref?: React.ForwardedRef<TableRef>;
+  ref?: ForwardedRef<TableRef>;
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-fluid-table",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "A React table inspired by react-window",
   "author": "Mckervin Ceme <mckervinc@live.com>",
   "license": "MIT",

--- a/src/AutoSizer.tsx
+++ b/src/AutoSizer.tsx
@@ -1,10 +1,98 @@
-import React, { useCallback, useEffect, useRef, useState } from "react";
+import React, { useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { TableContext } from "./TableContext";
+import { DEFAULT_HEADER_HEIGHT, DEFAULT_ROW_HEIGHT } from "./constants";
+import { findHeaderByUuid } from "./util";
 
 interface AutoSizerProps {
-  disableHeight?: boolean;
-  disableWidth?: boolean;
+  numRows: number;
+  rowHeight?: number;
+  tableWidth?: number;
+  tableHeight?: number;
+  minTableHeight?: number;
+  maxTableHeight?: number;
   children: ({ height, width }: { height: number; width: number }) => React.ReactNode;
 }
+
+interface Heights {
+  tableHeight: number;
+  containerHeight: number;
+  computedHeight: number;
+  minHeight: number;
+  maxHeight: number;
+}
+
+const findCorrectHeight = ({
+  tableHeight,
+  containerHeight,
+  computedHeight,
+  minHeight,
+  maxHeight
+}: Heights) => {
+  // case 1: tableHeight is specified, so just return that
+  if (tableHeight > 0) {
+    return tableHeight;
+  }
+
+  // case 2: min or max is specified. this means that the table can grow/shrink,
+  // depending upon the number of rows
+  if (minHeight > 0 || maxHeight > 0) {
+    let curr = computedHeight;
+    if (minHeight > 0) {
+      curr = Math.max(minHeight, curr);
+
+      // if no maxHeight provided, then treat
+      // the computedHeight as the maxHeight
+      if (!maxHeight && computedHeight > 0) {
+        return Math.max(curr, computedHeight);
+      }
+    }
+
+    if (maxHeight > 0) {
+      curr = Math.min(maxHeight, curr);
+    }
+
+    return curr;
+  }
+
+  // case 3: no min/max specified, so just return the containerHeight.
+  // if no containerHeight, return the computedHeight
+  return containerHeight || computedHeight;
+};
+
+const calculateHeight = (rowHeight: number, uuid: string, size: number) => {
+  // get the header and nodes
+  const header = findHeaderByUuid(uuid);
+  const nodes = [...(header?.nextElementSibling?.children || [])] as HTMLElement[];
+
+  if (!!header && !!nodes.length) {
+    // get border height
+    let borders = 0;
+    const table = header.parentElement?.parentElement;
+    if (!!table) {
+      borders = table.offsetHeight - table.clientHeight;
+    }
+
+    // perform calculation
+    if (rowHeight > 0) {
+      return header.clientHeight + nodes.length * rowHeight + borders;
+    }
+
+    let overscan = 0;
+    return (
+      header.clientHeight +
+      nodes.reduce((pv, c) => {
+        overscan = c.offsetHeight;
+        return pv + c.offsetHeight;
+      }, 0) +
+      overscan +
+      borders
+    );
+  }
+
+  // if the header and nodes are not specified, guess the height
+  const height = Math.max(rowHeight || DEFAULT_ROW_HEIGHT, 10);
+  return height * Math.min(size || 10, 10) + DEFAULT_HEADER_HEIGHT;
+};
 
 /**
  * This is a skinny AutoSizer based on react-virtualized-auto-sizer.
@@ -12,14 +100,44 @@ interface AutoSizerProps {
  * to generate its own height. This also ignores a resize if the
  * dimensions of the window did not actually change (one less render).
  */
-const AutoSizer = ({ disableHeight, disableWidth, children }: AutoSizerProps) => {
+const AutoSizer = ({
+  numRows,
+  rowHeight,
+  tableWidth,
+  tableHeight,
+  minTableHeight,
+  maxTableHeight,
+  children
+}: AutoSizerProps) => {
   // hooks
   const resizeRef = useRef(0);
   const ref = useRef<HTMLDivElement>(null);
-  const [dimensions, setDimensions] = useState({ height: 0, width: 0 });
+  const { uuid } = useContext(TableContext);
+  const [dimensions, setDimensions] = useState({ containerHeight: 0, containerWidth: 0 });
 
   // variables
-  const { height, width } = dimensions;
+  const { containerHeight, containerWidth } = dimensions;
+
+  // calculate the computed height
+  const computedHeight = useMemo(() => {
+    if (!!tableHeight && tableHeight > 0) {
+      return tableHeight;
+    }
+
+    return calculateHeight(rowHeight || 0, uuid, numRows);
+  }, [tableHeight, rowHeight, numRows, uuid]);
+
+  // calculate the actual height of the table
+  const height = findCorrectHeight({
+    computedHeight,
+    containerHeight,
+    tableHeight: tableHeight || 0,
+    minHeight: minTableHeight || 0,
+    maxHeight: maxTableHeight || 0
+  });
+
+  // get actual width
+  const width = !!tableWidth && tableWidth > 0 ? tableWidth : containerWidth;
 
   // functions
   const calculateDimensions = useCallback(() => {
@@ -41,8 +159,10 @@ const AutoSizer = ({ disableHeight, disableWidth, children }: AutoSizerProps) =>
     const newWidth = (parent.offsetWidth || 0) - paddingLeft - paddingRight;
 
     // update state
-    setDimensions({ height: newHeight, width: newWidth });
-  }, [height, width, disableHeight, disableWidth]);
+    if (newHeight !== containerHeight || newWidth !== containerWidth) {
+      setDimensions({ containerHeight: newHeight, containerWidth: newWidth });
+    }
+  }, [containerHeight, containerWidth]);
 
   const onResize = useCallback(() => {
     window.clearTimeout(resizeRef.current);
@@ -56,22 +176,14 @@ const AutoSizer = ({ disableHeight, disableWidth, children }: AutoSizerProps) =>
   // on resize, we have to re-calculate the dimensions
   useEffect(() => {
     window.addEventListener("resize", onResize);
+    const m = resizeRef.current;
     return () => {
-      window.clearTimeout(resizeRef.current);
+      window.clearTimeout(m);
       window.removeEventListener("resize", onResize);
     };
-  }, [onResize, resizeRef]);
+  }, [onResize]);
 
-  return (
-    <div ref={ref}>
-      {height || width
-        ? children({
-            height: disableHeight ? 0 : height,
-            width: disableWidth ? 0 : width
-          })
-        : null}
-    </div>
-  );
+  return <div ref={ref}>{height || width ? children({ height, width }) : null}</div>;
 };
 
 export default AutoSizer;

--- a/src/AutoSizer.tsx
+++ b/src/AutoSizer.tsx
@@ -155,8 +155,8 @@ const AutoSizer = ({
     const paddingBottom = parseInt(style.paddingBottom) || 0;
 
     // find new dimensions
-    const newHeight = (parent.offsetHeight || 0) - paddingTop - paddingBottom;
-    const newWidth = (parent.offsetWidth || 0) - paddingLeft - paddingRight;
+    const newHeight = Math.max((parent.offsetHeight || 0) - paddingTop - paddingBottom, 0);
+    const newWidth = Math.max((parent.offsetWidth || 0) - paddingLeft - paddingRight, 0);
 
     // update state
     if (newHeight !== containerHeight || newWidth !== containerWidth) {

--- a/src/Footer.tsx
+++ b/src/Footer.tsx
@@ -1,10 +1,40 @@
 import React, { useCallback, useContext, useEffect, useRef } from "react";
+import { ColumnProps } from "..";
 import { TableContext } from "./TableContext";
 import { cx, findTableByUuid } from "./util";
+
+interface InnerFooterCellProps<T> {
+  width: number;
+  column: ColumnProps<T>;
+}
+
+const FooterCell = React.memo(function <T>(props: InnerFooterCellProps<T>) {
+  // hooks
+  const { rows } = useContext(TableContext);
+
+  // instance
+  const { width, column } = props;
+  const style: React.CSSProperties = {
+    width: width ? `${width}px` : undefined,
+    minWidth: width ? `${width}px` : undefined,
+    padding: !column.footer ? 0 : undefined
+  };
+
+  const FooterCellComponent = column.footer;
+  return (
+    <div className="cell" style={style}>
+      {!!FooterCellComponent && <FooterCellComponent rows={rows} {...props} />}
+    </div>
+  );
+});
+
+FooterCell.displayName = "FooterCell";
 
 const Footer = () => {
   const {
     uuid,
+    rows,
+    columns,
     stickyFooter,
     pixelWidths,
     footerStyle,
@@ -67,7 +97,22 @@ const Footer = () => {
 
   // render
   if (!FooterComponent) {
-    return null;
+    const hasFooter = !!columns.find(c => !!c.footer);
+    return (
+      <div
+        ref={ref}
+        style={{ border: !hasFooter ? "none" : undefined, ...style }}
+        data-footer-key={`${uuid}-footer`}
+        className={cx(["react-fluid-table-footer", stickyFooter && "sticky", footerClassname])}
+        onScroll={e => onScroll(e.target as HTMLDivElement, findTableByUuid(uuid))}
+      >
+        <div className="row-container">
+          {columns.map((c, i) => (
+            <FooterCell key={c.key} column={c} width={pixelWidths[i]} />
+          ))}
+        </div>
+      </div>
+    );
   }
 
   return (
@@ -78,7 +123,7 @@ const Footer = () => {
       className={cx(["react-fluid-table-footer", stickyFooter && "sticky", footerClassname])}
       onScroll={e => onScroll(e.target as HTMLDivElement, findTableByUuid(uuid))}
     >
-      <FooterComponent widths={pixelWidths} />
+      <FooterComponent rows={rows} widths={pixelWidths} />
     </div>
   );
 };

--- a/src/Header.tsx
+++ b/src/Header.tsx
@@ -14,14 +14,14 @@ interface HeaderProps {
   style: React.CSSProperties;
 }
 
-function InnerHeaderCell<T>({ column, width }: HeaderCellProps<T>) {
+const HeaderCell = React.memo(function <T>({ column, width }: HeaderCellProps<T>) {
   // hooks
   const { dispatch, sortColumn: col, sortDirection, onSort } = useContext(TableContext);
 
   // constants
   const dir = sortDirection ? (sortDirection.toUpperCase() as SortDirection) : null;
 
-  const style = {
+  const style: React.CSSProperties = {
     cursor: column.sortable ? "pointer" : undefined,
     width: width ? `${width}px` : undefined,
     minWidth: width ? `${width}px` : undefined
@@ -70,9 +70,7 @@ function InnerHeaderCell<T>({ column, width }: HeaderCellProps<T>) {
   const ColumnCell = column.header;
   const headerDir = column.key === col ? dir || null : null;
   return <ColumnCell style={style} onClick={onClick} sortDirection={headerDir} />;
-}
-
-const HeaderCell = React.memo(InnerHeaderCell);
+});
 
 HeaderCell.displayName = "HeaderCell";
 

--- a/src/Row.tsx
+++ b/src/Row.tsx
@@ -65,7 +65,7 @@ const getRowClassname = (index: number, rowClassname?: string | CSSClassFunction
   return typeof rowClassname === "function" ? rowClassname(index) : rowClassname;
 };
 
-function InnerTableCell<T>({
+const TableCell = React.memo(function <T>({
   row,
   index,
   width,
@@ -118,9 +118,7 @@ function InnerTableCell<T>({
   // custom cell styling
   const CustomCell = column.cell;
   return <CustomCell row={row} index={index} style={style} clearSizeCache={clearSizeCache} />;
-}
-
-const TableCell = React.memo(InnerTableCell);
+});
 
 TableCell.displayName = "TableCell";
 

--- a/src/RowWrapper.tsx
+++ b/src/RowWrapper.tsx
@@ -6,16 +6,14 @@ interface Props<T> extends Omit<ListChildComponentProps<T>, "data"> {
   data: any;
 }
 
-function InnerRowWrapper<T>({ data, index, ...rest }: Props<T>) {
+const RowWrapper = React.memo(function <T>({ data, index, ...rest }: Props<T>) {
   const dataIndex = index - 1; // the header is at index 0
 
   const { rows, ...metaData } = data;
   const row: T = rows[dataIndex];
 
   return !row ? null : <Row row={row} index={dataIndex} {...rest} {...metaData} />;
-}
-
-const RowWrapper = React.memo(InnerRowWrapper, areEqual);
+}, areEqual);
 
 RowWrapper.displayName = "RowWrapper";
 

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -23,7 +23,6 @@ import {
   cx,
   findHeaderByUuid,
   findRowByUuidAndKey,
-  guessTableHeight,
   randomString
 } from "./util";
 
@@ -322,8 +321,6 @@ const Table = forwardRef(
     ref: React.ForwardedRef<TableRef>
   ) => {
     // TODO: do all prop validation here
-    const disableHeight = tableHeight !== undefined;
-    const disableWidth = tableWidth !== undefined;
     const [uuid] = useState(`${id || "data-table"}-${randomString(5)}`);
 
     return (
@@ -354,23 +351,21 @@ const Table = forwardRef(
             {...rest}
           />
         ) : (
-          <AutoSizer disableHeight={disableHeight} disableWidth={disableWidth}>
+          <AutoSizer
+            numRows={rest.data.length}
+            tableWidth={tableWidth}
+            tableHeight={tableHeight}
+            rowHeight={rest.rowHeight}
+            minTableHeight={minTableHeight}
+            maxTableHeight={maxTableHeight}
+          >
             {({ height, width }) => {
-              const componentHeight =
-                tableHeight ||
-                (maxTableHeight !== undefined && maxTableHeight >= 0
-                  ? Math.min(
-                      height || guessTableHeight(rest.rowHeight || 0, rest.data.length),
-                      maxTableHeight
-                    )
-                  : height || guessTableHeight(rest.rowHeight || 0));
-
               return (
                 <ListComponent
                   ref={ref}
                   borders={borders}
-                  width={tableWidth || width}
-                  height={Math.max(componentHeight, minTableHeight || 0)}
+                  width={width}
+                  height={height}
                   {...rest}
                 />
               );

--- a/src/TableContext.tsx
+++ b/src/TableContext.tsx
@@ -8,6 +8,7 @@ interface Action {
   key?: string | number;
   widths?: number[];
   initialState?: TableState;
+  rows?: any[];
 }
 
 interface ReactContext {
@@ -15,6 +16,7 @@ interface ReactContext {
 }
 
 interface TableState extends ReactContext {
+  rows: any[];
   pixelWidths: number[];
   uuid: string;
   minColumnWidth: number;
@@ -24,7 +26,7 @@ interface TableState extends ReactContext {
   sortColumn: string | null;
   sortDirection: SortDirection;
   stickyFooter: boolean;
-  footerComponent?: (props: FooterProps) => React.ReactNode;
+  footerComponent?: (props: FooterProps<any>) => React.ReactNode;
   expanded: {
     [key: string | number]: boolean;
   };
@@ -42,6 +44,7 @@ const baseState: TableState = {
   expanded: {},
   columns: [],
   pixelWidths: [],
+  rows: [],
   uuid: "",
   minColumnWidth: 80,
   fixedWidth: 0,
@@ -90,6 +93,8 @@ const reducer = (state: TableState, action: Action): TableState => {
       };
     case "updatePixelWidths":
       return { ...state, pixelWidths: action.widths || [] };
+    case "updateRows":
+      return { ...state, rows: action.rows || [] };
     case "refresh":
       return {
         ...state,

--- a/src/main.css
+++ b/src/main.css
@@ -1,8 +1,3 @@
-.react-fluid-table {
-  background-color: white;
-  border: 1px solid #ececec;
-}
-
 .react-fluid-table .cell,
 .react-fluid-table .header-cell {
   -webkit-box-sizing: border-box;
@@ -37,7 +32,6 @@
   display: -webkit-flex;
   display: -ms-flexbox;
   display: flex;
-  background-color: #dedede;
 }
 
 .header-cell {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,5 +1,4 @@
 import { ColumnProps } from "..";
-import { DEFAULT_HEADER_HEIGHT, DEFAULT_ROW_HEIGHT } from "./constants";
 
 /**
  * combines multiple classNames conditionally
@@ -47,11 +46,6 @@ export const findRowByUuidAndKey = (uuid: string, key: string | number): HTMLEle
   document.querySelector(`[data-row-key='${uuid}-${key}']`);
 
 // table utilities
-export const guessTableHeight = (rowHeight: number, size = 10) => {
-  const height = Math.max(rowHeight || DEFAULT_ROW_HEIGHT, 10);
-  return height * size + DEFAULT_HEADER_HEIGHT;
-};
-
 export const calculateColumnWidths = <T>(
   element: HTMLElement | null,
   numColumns: number,

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,6 +42,9 @@ export const findTableByUuid = (uuid: string): HTMLElement | null =>
 export const findHeaderByUuid = (uuid: string): HTMLElement | null =>
   document.querySelector(`[data-header-key='${uuid}-header']`);
 
+export const findFooterByUuid = (uuid: string): HTMLElement | null =>
+  document.querySelector(`[data-footer-key='${uuid}-footer']`);
+
 export const findRowByUuidAndKey = (uuid: string, key: string | number): HTMLElement | null =>
   document.querySelector(`[data-row-key='${uuid}-${key}']`);
 


### PR DESCRIPTION
- see https://github.com/mckervinc/react-fluid-table/issues/71
- limits the styling a bit
- fixes autoCalculation of table heights
- adds the ability to specify the `footer` inside of the `columns` array for some more footer customization